### PR TITLE
add cleanUp method on request correlation interceptor e.x. use case M…

### DIFF
--- a/src/main/java/io/jmnarloch/spring/request/correlation/api/RequestCorrelationInterceptor.java
+++ b/src/main/java/io/jmnarloch/spring/request/correlation/api/RequestCorrelationInterceptor.java
@@ -29,4 +29,11 @@ public interface RequestCorrelationInterceptor {
      * @param correlationId the correlation id
      */
     void afterCorrelationIdSet(String correlationId);
+
+    /**
+     * Callback method called after filter chain is completed.
+     *
+     * @param correlationId the correlation id
+     */
+    void cleanUp(String correlationId);
 }

--- a/src/main/java/io/jmnarloch/spring/request/correlation/filter/RequestCorrelationFilter.java
+++ b/src/main/java/io/jmnarloch/spring/request/correlation/filter/RequestCorrelationFilter.java
@@ -143,7 +143,11 @@ public class RequestCorrelationFilter implements Filter {
         final ServletRequest req = enrichRequest(request, requestCorrelation);
 
         // proceeds with execution
-        chain.doFilter(req, response);
+        try {
+            chain.doFilter(req, response);
+        } finally {
+            triggerInterceptorsCleanup(correlationId);
+        }
     }
 
     /**
@@ -176,6 +180,18 @@ public class RequestCorrelationFilter implements Filter {
 
         for (RequestCorrelationInterceptor interceptor : interceptors) {
             interceptor.afterCorrelationIdSet(correlationId);
+        }
+    }
+
+    /**
+     * Triggers the configured interceptors cleanUp methods.
+     *
+     * @param correlationId the correlation id
+     */
+    private void triggerInterceptorsCleanup(String correlationId) {
+
+        for (RequestCorrelationInterceptor interceptor : interceptors) {
+            interceptor.cleanUp(correlationId);
         }
     }
 


### PR DESCRIPTION
Hello jmnarloch,

I found your request correlation module and applied to my project with great success :). I really liked the structure and and the simplicity of your code. I also liked the idea of injecting the List of RestTemplate(s).

The thing I would like to add to it, is a cleanup method for the RequestCorrelationInterceptor.java .

I my case, I use these interceptor hook to add stuff to MDC(logback) thread local but I have no concrete way of removing data from it.

Thank you for your time
